### PR TITLE
Fixed bug where you couldn't shake zombie/creeper heads

### DIFF
--- a/src/main/resources/treasures.yml
+++ b/src/main/resources/treasures.yml
@@ -695,8 +695,7 @@ Shake:
             Drop_Chance: 49.0
             Drop_Level: 0
     CREEPER:
-        SKELETON_SKULL:
-            Data: 4
+        CREEPER_HEAD:
             Amount: 1
             XP: 0
             Drop_Chance: 1.0
@@ -828,7 +827,6 @@ Shake:
             Drop_Level: 0
     SKELETON:
         SKELETON_SKULL:
-            Data: 0
             Amount: 1
             XP: 0
             Drop_Chance: 2.0
@@ -951,7 +949,7 @@ Shake:
             Drop_Chance: 49.0
             Drop_Level: 0
     ZOMBIE:
-        SKELETON_SKULL:
+        ZOMBIE_HEAD:
             Amount: 1
             XP: 0
             Drop_Chance: 2.0


### PR DESCRIPTION
Fixed bug where skeleton heads would drop in instead of zombie/creeper heads on successful shake

Creeper/zombie heads are now their own items and data is no longer used